### PR TITLE
[API_KEY]Add fake api key to make the app working with the API (heroku)

### DIFF
--- a/app/javascript/packs/admin.js
+++ b/app/javascript/packs/admin.js
@@ -23,7 +23,7 @@ window.f = Form;
 window.loadAdministerForm = (element, formId) => {
   Form.get(formId).then(form => {
     const store = createAdministerFormStore(
-      new AdministerFormModel({ form: form })
+      new AdministerFormModel({ form: form, apiKey: "API_KEY" })
     );
     ReactDOM.render(
       <Provider store={store}>

--- a/app/javascript/packs/respond_to_form.js
+++ b/app/javascript/packs/respond_to_form.js
@@ -22,7 +22,9 @@ window.f = Form;
 
 window.loadRespondToForm = (element, formId, displaySectionsAs) => {
   Form.get(formId).then(form => {
-    const store = createRespondToFormStore(new Model({ form: form }));
+    const store = createRespondToFormStore(
+      new Model({ form: form, apiKey: "API_KEY" })
+    );
     ReactDOM.render(
       <Provider store={store}>
         <RespondToForm displaySectionsAs={displaySectionsAs} />


### PR DESCRIPTION
Currently, we have added a token based authentication in our app. Our example app should have the api key. I'm passing a fake api key just to make it work as an example app. We pass the API_KEY in our store.

We will need to update our formulae_react version, because the next version contains the api key for the model.